### PR TITLE
changed type of output from string to array

### DIFF
--- a/base64.js
+++ b/base64.js
@@ -1,7 +1,7 @@
 let keyStr = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=';
 export default {
-    encode: function(input) {
-        var output = "";
+    encode: function (input) {
+        var output = [];
         var chr1, chr2, chr3 = "";
         var enc1, enc2, enc3, enc4 = "";
         var i = 0;
@@ -22,19 +22,19 @@ export default {
                 enc4 = 64;
             }
 
-            output = output +
+            output.push(
                 keyStr.charAt(enc1) +
                 keyStr.charAt(enc2) +
                 keyStr.charAt(enc3) +
-                keyStr.charAt(enc4);
+                keyStr.charAt(enc4))
             chr1 = chr2 = chr3 = "";
             enc1 = enc2 = enc3 = enc4 = "";
         } while (i < input.length);
 
-        return output;
+        return output.join('');
     },
 
-    decode: function(input) {
+    decode: function (input) {
         var output = "";
         var chr1, chr2, chr3 = "";
         var enc1, enc2, enc3, enc4 = "";


### PR DESCRIPTION
As the type of output is string time taken to append to the string increases linearly as time increases. But if an array is used it would be way faster as append into array takes O(1). This increases speed of encoding larger images tremendously which can be clearly seen. I have tried to encode an image whose string size is 200,000. Using string took 34seconds and using array took only 200 milliseconds. So the encoding would be way faster than usual.